### PR TITLE
Returns methods with Func delegate as parameter in Arrangement<TResult> class

### DIFF
--- a/LightMock.Tests/ArrangementTests.cs
+++ b/LightMock.Tests/ArrangementTests.cs
@@ -15,7 +15,7 @@
             fooMock.Execute();
             Assert.IsTrue(isCalled);
         }
-                
+
         [TestMethod]
         public void Arrange_CallBackOneArgument_InvokesCallback()
         {
@@ -36,10 +36,10 @@
             int secondResult = 0;
             mockContext.Arrange(f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue)).Callback<int, int>(
                 (i, i1) =>
-                    {
-                        firstResult = i;
-                        secondResult = i1;
-                    });
+                {
+                    firstResult = i;
+                    secondResult = i1;
+                });
             fooMock.Execute(1, 2);
             Assert.AreEqual(1, firstResult);
             Assert.AreEqual(2, secondResult);
@@ -53,16 +53,17 @@
             int firstResult = 0;
             int secondResult = 0;
             int thirdResult = 0;
-            mockContext.Arrange(f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue)).Callback<int, int, int>(
-                (i1, i2, i3) =>
-                {
-                    firstResult = i1;
-                    secondResult = i2;
-                    thirdResult = i3;
-                });
-            
+            mockContext.Arrange(f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue))
+                .Callback<int, int, int>(
+                    (i1, i2, i3) =>
+                    {
+                        firstResult = i1;
+                        secondResult = i2;
+                        thirdResult = i3;
+                    });
+
             fooMock.Execute(1, 2, 3);
-            
+
             Assert.AreEqual(1, firstResult);
             Assert.AreEqual(2, secondResult);
             Assert.AreEqual(3, thirdResult);
@@ -77,14 +78,16 @@
             int secondResult = 0;
             int thirdResult = 0;
             int fourthResult = 0;
-            mockContext.Arrange(f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue)).Callback<int, int, int, int>(
-                (i1, i2, i3, i4) =>
-                {
-                    firstResult = i1;
-                    secondResult = i2;
-                    thirdResult = i3;
-                    fourthResult = i4;
-                });
+            mockContext.Arrange(
+                f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue))
+                .Callback<int, int, int, int>(
+                    (i1, i2, i3, i4) =>
+                    {
+                        firstResult = i1;
+                        secondResult = i2;
+                        thirdResult = i3;
+                        fourthResult = i4;
+                    });
 
             fooMock.Execute(1, 2, 3, 4);
 
@@ -94,7 +97,67 @@
             Assert.AreEqual(4, fourthResult);
         }
 
+        [TestMethod]
+        public void Arrange_ReturnsWithNoArguments_InvokesGetResult()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
 
-        
+            mockContext.Arrange(f => f.Execute()).Returns(() => "This");
+            var result = fooMock.Execute();
+            Assert.AreEqual("This", result);
+        }
+
+        [TestMethod]
+        public void Arrange_ReturnsWithOneArgument_InvokesGetResult()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            mockContext.Arrange(f => f.Execute(The<string>.IsAnyValue)).Returns<string>(a => "This" + a);
+            var result = fooMock.Execute(" is");
+            Assert.AreEqual("This is", result);
+        }
+
+        [TestMethod]
+        public void Arrange_ReturnsWithTwoArguments_InvokesGetResult()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            mockContext.Arrange(f => f.Execute(The<string>.IsAnyValue, The<string>.IsAnyValue))
+                .Returns<string, string>((a, b) => "This" + a + b);
+            var result = fooMock.Execute(" is", " really");
+            Assert.AreEqual("This is really", result);
+        }
+
+        [TestMethod]
+        public void Arrange_ReturnsWithThreeArguments_InvokesGetResult()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            mockContext.Arrange(f => f.Execute(The<string>.IsAnyValue, The<string>.IsAnyValue, The<string>.IsAnyValue))
+                .Returns<string, string, string>((a, b, c) => "This" + a + b + c);
+
+            var result = fooMock.Execute(" is", " really", " cool");
+            Assert.AreEqual("This is really cool", result);
+        }
+
+        [TestMethod]
+        public void Arrange_ReturnsWithFourArguments_InvokesGetResult()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            mockContext.Arrange(
+                f =>
+                    f.Execute(
+                        The<string>.IsAnyValue,
+                        The<string>.IsAnyValue,
+                        The<string>.IsAnyValue,
+                        The<string>.IsAnyValue))
+                .Returns<string, string, string, string>((a, b, c, d) => "This" + a + b + c + d);
+            fooMock.Execute(1, 2, 3, 4);
+
+            var result = fooMock.Execute(" is", " really", " cool", "!");
+            Assert.AreEqual("This is really cool!", result);
+        }
     }
 }

--- a/LightMock.Tests/FooMock.cs
+++ b/LightMock.Tests/FooMock.cs
@@ -5,15 +5,15 @@
     public class FooMock : IFoo
     {
         private readonly IInvocationContext<IFoo> context;
-        
+
         public FooMock(IInvocationContext<IFoo> context)
         {
             this.context = context;
         }
 
-        public void Execute(string value)
+        public string Execute(string value)
         {
-            context.Invoke(f => f.Execute(value));
+            return context.Invoke(f => f.Execute(value));
         }
 
         public void Execute(int first)
@@ -39,6 +39,21 @@
         public string Execute()
         {
             return context.Invoke(f => f.Execute());
-        }        
+        }
+
+        public string Execute(string first, string second)
+        {
+            return context.Invoke(f => f.Execute(first, second));
+        }
+
+        public string Execute(string first, string second, string third)
+        {
+            return context.Invoke(f => f.Execute(first, second, third));
+        }
+
+        public string Execute(string first, string second, string third, string fourth)
+        {
+            return context.Invoke(f => f.Execute(first, second, third, fourth));
+        }
     }
 }

--- a/LightMock.Tests/FooMock.cs
+++ b/LightMock.Tests/FooMock.cs
@@ -55,5 +55,10 @@
         {
             return context.Invoke(f => f.Execute(first, second, third, fourth));
         }
+
+        public byte[] Execute(byte[] array)
+        {
+            return context.Invoke((f => f.Execute(array)));
+        }
     }
 }

--- a/LightMock.Tests/IFoo.cs
+++ b/LightMock.Tests/IFoo.cs
@@ -12,6 +12,8 @@
         string Execute(string first, string second);
         string Execute(string first, string second, string third);
         string Execute(string first, string second, string third, string fourth);
+
+        byte[] Execute(byte[] array);
     }
 
     public interface IBar

--- a/LightMock.Tests/IFoo.cs
+++ b/LightMock.Tests/IFoo.cs
@@ -1,18 +1,17 @@
 ﻿namespace LightMock.Tests
 {
-    using System;
-
     public interface IFoo
     {
-        void Execute(string value);
         void Execute(int first);
         void Execute(int first, int second);
         void Execute(int first, int second, int third);
         void Execute(int first, int second, int third, int fourth);
 
-        
-
-        string Execute();        
+        string Execute();
+        string Execute(string value);
+        string Execute(string first, string second);
+        string Execute(string first, string second, string third);
+        string Execute(string first, string second, string third, string fourth);
     }
 
     public interface IBar

--- a/LightMock.Tests/LightMock.Tests.csproj
+++ b/LightMock.Tests/LightMock.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ExpressionExtensions.cs" />
     <Compile Include="FooMock.cs" />
     <Compile Include="IFoo.cs" />
+    <Compile Include="PropMock.cs" />
     <Compile Include="MockContextTests.cs" />
     <Compile Include="MatchInfoTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/LightMock.Tests/MockContextTests.cs
+++ b/LightMock.Tests/MockContextTests.cs
@@ -158,9 +158,9 @@ namespace LightMock.Tests
             var mockContext = new MockContext<IFoo>();
             var fooMock = new FooMock(mockContext);
 
-            fooMock.Execute(null);
+            fooMock.Execute((string)null);
 
-            mockContext.Assert(f => f.Execute(null));
+            mockContext.Assert(f => f.Execute((string)null));
         }
 
         [TestMethod]
@@ -175,7 +175,7 @@ namespace LightMock.Tests
         }
 
         [TestMethod]
-        public void Execute_ArrengedReturnValue_ReturnsValueUsingLambda()
+        public void Execute_ArrangedReturnValue_ReturnsValueUsingLambda()
         {
             var mockContext = new MockContext<IFoo>();
             var fooMock = new FooMock(mockContext);
@@ -190,6 +190,32 @@ namespace LightMock.Tests
             var result = fooMock.Execute("It");
 
             Assert.AreEqual("It works!", result);
+        }
+
+        [TestMethod]
+        public void Execute_ArrangedRuturnValue_ArrayLengthContraintSupport()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            var inputData = Enumerable.Repeat((byte)1, 10).ToArray();
+            mockContext.Arrange(
+                f => f.Execute(The<byte[]>.Is(a => a.Length < 20)))
+                .Returns<byte[]>(a => a);
+            var result = fooMock.Execute(inputData);
+            Assert.AreEqual(inputData, result);
+        }
+
+        [TestMethod]
+        public void Execute_ArrangedRuturnValue_ArrayElementContraintSupport()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            var inputData = new byte[] {1, 2, 3, 4, 5 };
+            mockContext.Arrange(
+                f => f.Execute(The<byte[]>.Is(a => a[4] == 5)))
+                .Returns<byte[]>(a => a);
+            var result = fooMock.Execute(inputData);
+            Assert.AreEqual(inputData, result);
         }
     }
 }

--- a/LightMock.Tests/MockContextTests.cs
+++ b/LightMock.Tests/MockContextTests.cs
@@ -100,6 +100,75 @@ namespace LightMock.Tests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Assert_ExpectedAtLeast3TimesAnd2TimesInvoked_ThrowsException()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"), Invoked.AtLeast(3));
+        }
+
+        [TestMethod]
+        public void Assert_ExpectedAtLeast3TimesAnd3TimesInvoked_IsVerified()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"), Invoked.AtLeast(3));
+        }
+
+        [TestMethod]
+        public void Assert_ExpectedAtLeast3TimesAnd4TimesInvoked_IsVerified()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"), Invoked.AtLeast(3));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Assert_ExpectedExactly3TimesAnd2TimesInvoked_ThrowsException()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"), Invoked.Exactly(3));
+        }
+
+        [TestMethod]
+        public void Assert_ExpectedExactly3TimesAnd3TimesInvoked_IsVerified()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"), Invoked.Exactly(3));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Assert_ExpectedExactly3TimesAnd4TimesInvoked_ThrowsException()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"), Invoked.Exactly(3));
+        }
+
+        [TestMethod]
         public void Assert_IsAnyValue_IsVerified()
         {
             var mockContext = new MockContext<IFoo>();

--- a/LightMock.Tests/MockContextTests.cs
+++ b/LightMock.Tests/MockContextTests.cs
@@ -286,5 +286,32 @@ namespace LightMock.Tests
             var result = fooMock.Execute(inputData);
             Assert.AreEqual(inputData, result);
         }
+
+        [TestMethod]
+        public void PropertySupport_ArrangeGetterReturnValue_IsVerified()
+        {
+            var mockContext = new MockContext<IProp>();
+            var propMock = new PropMock(mockContext);
+            mockContext.Arrange(x => x.ReadOnlyProperty).Returns(() => "result");
+
+            var propertyValue = propMock.ReadOnlyProperty;
+            Assert.AreEqual("result", propertyValue);
+        }
+
+        [TestMethod]
+        public void PropertySupport_ArrangeGetterAndSetter_IsVerified()
+        {
+            var mockContext = new MockContext<IProp>();
+            var propMock = new PropMock(mockContext);
+            mockContext.ArrangeProperty(x => x.TwoWayProperty);
+
+            var propertyValue = propMock.TwoWayProperty;
+            Assert.IsNull(propertyValue);
+
+            propMock.TwoWayProperty = "customValue";
+
+            propertyValue = propMock.TwoWayProperty;
+            Assert.AreEqual("customValue", propertyValue);
+        }
     }
 }

--- a/LightMock.Tests/MockContextTests.cs
+++ b/LightMock.Tests/MockContextTests.cs
@@ -1,20 +1,17 @@
 ﻿using System;
+using System.Linq;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LightMock.Tests
 {
-    using System.Collections.Specialized;
-    using System.Linq;
-
-    using LightMock;
-
     [TestClass]
     public class MockContextTests
     {
         [TestMethod]
         public void Assert_Never_IsVerified()
         {
-            var mockContext = new MockContext<IFoo>();            
+            var mockContext = new MockContext<IFoo>();
             mockContext.Assert(f => f.Execute("SomeValue"), Invoked.Never);
         }
 
@@ -24,7 +21,7 @@ namespace LightMock.Tests
         {
             var mockContext = new MockContext<IFoo>();
             var fooMock = new FooMock(mockContext);
-            fooMock.Execute("SomeValue");            
+            fooMock.Execute("SomeValue");
             mockContext.Assert(f => f.Execute("SomeValue"), Invoked.Never);
         }
 
@@ -32,9 +29,9 @@ namespace LightMock.Tests
         public void Assert_Once_IsVerified()
         {
             var mockContext = new MockContext<IFoo>();
-            var fooMock = new FooMock(mockContext);            
-            fooMock.Execute("SomeValue");            
-            mockContext.Assert(f => f.Execute("SomeValue"));            
+            var fooMock = new FooMock(mockContext);
+            fooMock.Execute("SomeValue");
+            mockContext.Assert(f => f.Execute("SomeValue"));
         }
 
         [TestMethod]
@@ -51,7 +48,7 @@ namespace LightMock.Tests
         [ExpectedException(typeof(InvalidOperationException))]
         public void Assert_WithoutInvocation_ThrowsException()
         {
-            var mockContext = new MockContext<IFoo>();            
+            var mockContext = new MockContext<IFoo>();
             mockContext.Assert(f => f.Execute("SomeValue"));
         }
 
@@ -88,7 +85,7 @@ namespace LightMock.Tests
         {
             var mockContext = new MockContext<IFoo>();
             var fooMock = new FooMock(mockContext);
-            fooMock.Execute("SomeValue");                        
+            fooMock.Execute("SomeValue");
             mockContext.Assert(f => f.Execute(The<string>.Is(s => s.StartsWith("Some"))), Invoked.Once);
         }
 
@@ -108,7 +105,7 @@ namespace LightMock.Tests
             var mockContext = new MockContext<IFoo>();
             var fooMock = new FooMock(mockContext);
             fooMock.Execute("SomeValue");
-            mockContext.Assert(f => f.Execute(The<string>.IsAnyValue), Invoked.Once);                        
+            mockContext.Assert(f => f.Execute(The<string>.IsAnyValue), Invoked.Once);
         }
 
         [TestMethod]
@@ -120,8 +117,6 @@ namespace LightMock.Tests
             mockContext.Arrange(f => f.Execute("SomeValue")).Throws<InvalidOperationException>();
             fooMock.Execute("SomeValue");
         }
-
-       
 
         [TestMethod]
         public void Execute_ArrengedReturnValue_ReturnsValue()
@@ -139,7 +134,7 @@ namespace LightMock.Tests
         public void Execute_NoArrangement_ReturnsDefaultValue()
         {
             var mockContext = new MockContext<IFoo>();
-            var fooMock = new FooMock(mockContext);            
+            var fooMock = new FooMock(mockContext);
 
             string result = fooMock.Execute();
 
@@ -177,6 +172,24 @@ namespace LightMock.Tests
             fooMock.Execute(string.Empty);
 
             mockContext.Assert(f => f.Execute(string.Empty));
+        }
+
+        [TestMethod]
+        public void Execute_ArrengedReturnValue_ReturnsValueUsingLambda()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            var outerVariable = " works";
+            mockContext.Arrange(f => f.Execute(The<string>.IsAnyValue)).Returns<string>(
+                a =>
+                {
+                    var r = a + outerVariable + "!";
+                    return r;
+                });
+
+            var result = fooMock.Execute("It");
+
+            Assert.AreEqual("It works!", result);
         }
     }
 }

--- a/LightMock.Tests/PropMock.cs
+++ b/LightMock.Tests/PropMock.cs
@@ -1,0 +1,39 @@
+﻿
+namespace LightMock.Tests
+{
+    public interface IProp
+    {
+        string ReadOnlyProperty { get; }
+        string TwoWayProperty { get; set; }
+    }
+
+    public class PropMock : IProp
+    {
+        private readonly IInvocationContext<IProp> _context;
+
+        public PropMock(IInvocationContext<IProp> context)
+        {
+            _context = context;
+        }
+
+        public string ReadOnlyProperty
+        {
+            get
+            {
+                return _context.Invoke(x => x.ReadOnlyProperty);
+            }
+        }
+
+        public string TwoWayProperty
+        {
+            get
+            {
+                return _context.Invoke(x => x.TwoWayProperty);
+            }
+            set
+            {
+                _context.InvokeSetter(x => x.TwoWayProperty, value);
+            }
+        }
+    }
+}

--- a/LightMock/ArrangementOfT.cs
+++ b/LightMock/ArrangementOfT.cs
@@ -24,6 +24,9 @@
     https://github.com/seesharper/LightMock
     http://twitter.com/bernhardrichter
 ******************************************************************************/
+
+using System;
+
 namespace LightMock
 {
     using System.Linq.Expressions;
@@ -36,6 +39,8 @@ namespace LightMock
     public class Arrangement<TResult> : Arrangement
     {
         private TResult result;
+
+        private Func<object[], TResult> getResult;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Arrangement{TResult}"/> class.
@@ -53,7 +58,67 @@ namespace LightMock
         /// <param name="value">The value to be returned from the mocked method.</param>
         public void Returns(TResult value)
         {
-            result = value;            
+            result = value;
+        }
+
+        /// <summary>
+        /// Arranges for the mocked method to return a value of type <typeparamref name="TResult"/>. 
+        /// Return value is set by the <paramref name="getResultFunc"/> when the mocked method is invoked.
+        /// </summary>
+        /// <param name="getResultFunc">The <see cref="Func{TResult}"/> is executed and returns value when the mocked method is invoked.</param>
+        public void Returns(Func<TResult> getResultFunc)
+        {
+            getResult = args => (TResult)getResultFunc.DynamicInvoke(args);
+        }
+
+        /// <summary>
+        /// Arranges for the mocked method to return a value of type <typeparamref name="TResult"/>. 
+        /// Return value is set by the <paramref name="getResultFunc"/> when the mocked method is invoked.
+        /// </summary>
+        /// <typeparam name="T">The type of the first parameter.</typeparam>
+        /// <param name="getResultFunc">The <see cref="Func{T, TResult}"/> is executed and returns value when the mocked method is invoked.</param>
+        public void Returns<T>(Func<T, TResult> getResultFunc)
+        {
+            getResult = args => (TResult)getResultFunc.DynamicInvoke(args);
+        }
+
+        /// <summary>
+        /// Arranges for the mocked method to return a value of type <typeparamref name="TResult"/>. 
+        /// Return value is set by the <paramref name="getResultFunc"/> when the mocked method is invoked.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter.</typeparam>
+        /// <param name="getResultFunc">The <see cref="Func{T1, T2, TResult}"/> is executed and returns value when the mocked method is invoked.</param>
+        public void Returns<T1, T2>(Func<T1, T2, TResult> getResultFunc)
+        {
+            getResult = args => (TResult)getResultFunc.DynamicInvoke(args);
+        }
+
+        /// <summary>
+        /// Arranges for the mocked method to return a value of type <typeparamref name="TResult"/>. 
+        /// Return value is set by the <paramref name="getResultFunc"/> when the mocked method is invoked.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter.</typeparam>
+        /// <param name="getResultFunc">The <see cref="Func{T1, T2, T3, TResult}"/> is executed and returns value when the mocked method is invoked.</param>
+        public void Returns<T1, T2, T3>(Func<T1, T2, T3, TResult> getResultFunc)
+        {
+            getResult = args => (TResult)getResultFunc.DynamicInvoke(args);
+        }
+
+        /// <summary>
+        /// Arranges for the mocked method to return a value of type <typeparamref name="TResult"/>. 
+        /// Return value is set by the <paramref name="getResultFunc"/> when the mocked method is invoked.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
+        /// <param name="getResultFunc">The <see cref="Func{T1, T2, T3, T4, TResult}"/> is executed and returns value when the mocked method is invoked.</param>
+        public void Returns<T1, T2, T3, T4>(Func<T1, T2, T3, T4, TResult> getResultFunc)
+        {
+            getResult = args => (TResult)getResultFunc.DynamicInvoke(args);
         }
 
         /// <summary>
@@ -63,7 +128,13 @@ namespace LightMock
         /// <returns>The registered return value, if any, otherwise, the default value.</returns>
         internal override object Execute(object[] arguments)
         {
-            base.Execute(arguments);            
+            base.Execute(arguments);
+
+            if (getResult != null)
+            {
+                result = getResult(arguments);
+            }
+
             return result;
         }
     }

--- a/LightMock/ExpressionReflect/ExpressionReflectorExecutor.cs
+++ b/LightMock/ExpressionReflect/ExpressionReflectorExecutor.cs
@@ -1,4 +1,6 @@
-﻿namespace ExpressionReflect
+﻿using System.Collections;
+
+namespace ExpressionReflect
 {
 	using System;
 	using System.Collections.Generic;
@@ -283,8 +285,8 @@
 						value = values.First() ?? values.Last();
 						break;
 					case ExpressionType.ArrayIndex:
-						object[] array = (object[])values.First();
-						value = array[Convert.ToInt64(values.Last())];
+						var array = (IList)values.First();
+						value = array[Convert.ToInt32(values.Last())];
 						break;
 					default:
 						throw new ArgumentOutOfRangeException();
@@ -352,7 +354,7 @@
 						result = checked(Convert.ChangeType(value, u.Type, CultureInfo.InvariantCulture));
 						break;
 					case ExpressionType.ArrayLength:
-						result = ((object[])value).Length;
+						result = ((Array)value).Length;
 						break;
 					case ExpressionType.TypeAs:
 						try

--- a/LightMock/IInvocationContext.cs
+++ b/LightMock/IInvocationContext.cs
@@ -54,5 +54,14 @@ namespace LightMock
         /// <returns>An instance of <typeparamref name="TResult"/> or possibly null 
         /// if <typeparamref name="TResult"/> a reference type.</returns>
         TResult Invoke<TResult>(Expression<Func<TMock, TResult>> expression);
+
+        /// <summary>
+        /// Tracks that the setter represented by the <paramref name="expression"/>
+        /// has been invoked.
+        /// </summary>
+        /// <param name="expression">The <see cref="Expression{TDelegate}"/> that 
+        /// represents the setter that has been invoked.</param>
+        /// <param name="value">The value</param>
+        void InvokeSetter<TResult>(Expression<Func<TMock, TResult>> expression, object value);
     }
 }

--- a/LightMock/IMockContext.cs
+++ b/LightMock/IMockContext.cs
@@ -28,6 +28,15 @@
         Arrangement<TResult> Arrange<TResult>(Expression<Func<TMock, TResult>> matchExpression);
 
         /// <summary>
+        /// Arranges a mocked property. 
+        /// </summary>
+        /// <typeparam name="TResult">The type of value returned from the mocked property.</typeparam>
+        /// <param name="matchExpression">The match expression that describes where 
+        /// this <see cref="PropertyArrangement{TResult}"/> will be applied.</param>
+        /// <returns>A new <see cref="PropertyArrangement{TResult}"/> used to apply property behavior.</returns>
+        PropertyArrangement<TResult> ArrangeProperty<TResult>(Expression<Func<TMock, TResult>> matchExpression);
+
+        /// <summary>
         /// Verifies that the method represented by the <paramref name="matchExpression"/> has 
         /// been invoked.
         /// </summary>

--- a/LightMock/InvocationInfo.cs
+++ b/LightMock/InvocationInfo.cs
@@ -24,6 +24,9 @@
     https://github.com/seesharper/LightMock
     http://twitter.com/bernhardrichter
 ******************************************************************************/
+
+using System.Linq.Expressions;
+
 namespace LightMock
 {
     using System.Reflection;
@@ -40,18 +43,34 @@ namespace LightMock
         /// <param name="arguments">The arguments used to invoked the method.</param>
         public InvocationInfo(MethodInfo method, object[] arguments)
         {
-            Method = method;
+            Member = method;
             Arguments = arguments;
+            ExpressionType = ExpressionType.Call;
         }
 
         /// <summary>
-        /// Gets the invoked method.
+        /// Initializes a new instance of the <see cref="InvocationInfo"/> class.
         /// </summary>
-        public MethodInfo Method { get; private set; }
+        /// <param name="memberInfo">The invoked property member</param>
+        public InvocationInfo(MemberInfo memberInfo)
+        {
+            Member = memberInfo;
+            ExpressionType = ExpressionType.MemberAccess;
+        }
+
+        /// <summary>
+        /// Get the invoked member.
+        /// </summary>
+        public MemberInfo Member { get; private set; }
 
         /// <summary>
         /// Gets the arguments used to invoke the method.
         /// </summary>
-        public object[] Arguments { get; private set; }        
+        public object[] Arguments { get; private set; }
+
+        /// <summary>
+        /// Gets the expression type.
+        /// </summary>
+        public ExpressionType ExpressionType { get; private set; }
     }
 }

--- a/LightMock/InvocationInfoBuilder.cs
+++ b/LightMock/InvocationInfoBuilder.cs
@@ -24,6 +24,9 @@
     https://github.com/seesharper/LightMock
     http://twitter.com/bernhardrichter
 ******************************************************************************/
+
+using System;
+
 namespace LightMock
 {
     using System.Collections.ObjectModel;
@@ -52,11 +55,24 @@ namespace LightMock
         /// the target method and the arguments used to invoke the method.</returns>
         public InvocationInfo Build(LambdaExpression expression)
         {
-            targetMethod = ((MethodCallExpression)expression.Body).Method;
-            arguments = new Collection<object>();            
-            Visit(expression);            
-            
-            return new InvocationInfo(targetMethod, arguments.ToArray());
+            var methodCallExpresssion = expression.Body as MethodCallExpression;
+            if (methodCallExpresssion != null)
+            {
+                targetMethod = methodCallExpresssion.Method;
+                arguments = new Collection<object>();
+                Visit(expression);
+
+                return new InvocationInfo(targetMethod, arguments.ToArray()); 
+            }
+            var memberExpression = expression.Body as MemberExpression;
+            if (memberExpression != null)
+            {
+                var memberInfo = memberExpression.Member; 
+                Visit(expression);
+                return new InvocationInfo(memberInfo);
+            }
+
+            throw new NotSupportedException(string.Format("Expression type ({0}) not supported.", expression.Body.NodeType));
         }
 
         /// <summary>

--- a/LightMock/Invoked.cs
+++ b/LightMock/Invoked.cs
@@ -75,7 +75,17 @@ namespace LightMock
         /// <returns>An <see cref="Invoked"/> instance that represent the expected number of invocations.</returns>
         public static Invoked AtLeast(int callCount)
         {
-            return new Invoked(i => i > 0);
+            return new Invoked(i => i >= callCount);
+        }
+
+        /// <summary>
+        /// Specifies that the mocked method should be invoked a given number of times.
+        /// </summary>
+        /// <param name="callCount">The expected number of times for the mocked method to be invoked.</param>
+        /// <returns>An <see cref="Invoked"/> instance that represent the expected number of invocations.</returns>
+        public static Invoked Exactly(int callCount)
+        {
+            return new Invoked(i => i == callCount);
         }
 
         /// <summary>

--- a/LightMock/LightMock.csproj
+++ b/LightMock/LightMock.csproj
@@ -54,6 +54,7 @@
     <Compile Include="MockContext.cs" />
     <Compile Include="MatchInfoBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyArrangement.cs" />
     <Compile Include="The.cs" />
     <Compile Include="Invoked.cs" />
   </ItemGroup>

--- a/LightMock/MatchInfo.cs
+++ b/LightMock/MatchInfo.cs
@@ -36,7 +36,7 @@ namespace LightMock
     /// </summary>
     internal class MatchInfo
     {
-        private readonly MethodInfo method;
+        private readonly MemberInfo member;
 
         private readonly LambdaExpression[] matchExpressions;
 
@@ -48,9 +48,20 @@ namespace LightMock
         /// represents matching argument values.</param>
         public MatchInfo(MethodInfo method, LambdaExpression[] matchExpressions)
         {
-            this.method = method;
+            this.member = method;
             this.matchExpressions = matchExpressions;
-        }                
+            ExpressionType = ExpressionType.Call;
+        }  
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MatchInfo"/> class.
+        /// </summary>
+        /// <param name="memberInfo">The target member to match.</param>
+        public MatchInfo(MemberInfo memberInfo)
+        {
+            member = memberInfo;
+            ExpressionType = ExpressionType.MemberAccess;
+        }
 
         /// <summary>
         /// Determines if the <paramref name="invocationInfo"/> matches this <see cref="MatchInfo"/>.
@@ -59,11 +70,15 @@ namespace LightMock
         /// <returns><b>True</b> if the <paramref name="invocationInfo"/> matches 
         /// this <see cref="MatchInfo"/>, otherwise, <b>False</b>.</returns>
         public bool Matches(InvocationInfo invocationInfo)
-        {            
-            if (method != invocationInfo.Method)
+        {
+            if (ExpressionType != invocationInfo.ExpressionType) return false;
+            
+            if (member != invocationInfo.Member)
             {
                 return false;
             }
+
+            if (ExpressionType == ExpressionType.MemberAccess) return true;
 
             if (matchExpressions.Length != invocationInfo.Arguments.Length)
             {
@@ -72,5 +87,10 @@ namespace LightMock
 
             return !matchExpressions.Where((t, i) => !(bool)t.Execute(invocationInfo.Arguments[i])).Any();
         }
+
+        /// <summary>
+        /// Gets the expression type.
+        /// </summary>
+        public ExpressionType ExpressionType { get; private set; }
     }
 }

--- a/LightMock/MatchInfoBuilder.cs
+++ b/LightMock/MatchInfoBuilder.cs
@@ -24,6 +24,9 @@
     https://github.com/seesharper/LightMock
     http://twitter.com/bernhardrichter
 ******************************************************************************/
+
+using System;
+
 namespace LightMock
 {
     using System.Collections.ObjectModel;
@@ -51,9 +54,22 @@ namespace LightMock
         /// matching an argument value.</returns>      
         public MatchInfo Build(LambdaExpression expression)
         {
-            targetMethod = ((MethodCallExpression)expression.Body).Method;
-            Visit(expression);
-            return new MatchInfo(targetMethod, lambdaExpressions.ToArray());
+            var methodCallExpresssion = expression.Body as MethodCallExpression;
+            if (methodCallExpresssion != null)
+            {
+                targetMethod = methodCallExpresssion.Method;
+                Visit(expression);
+                return new MatchInfo(targetMethod, lambdaExpressions.ToArray());
+            }
+            var memberExpression = expression.Body as MemberExpression;
+            if (memberExpression != null)
+            {
+                var memberInfo = memberExpression.Member;
+                Visit(expression);
+                return new MatchInfo(memberInfo);
+            }
+
+            throw new NotSupportedException(string.Format("Expression type ({0}) not supported.", expression.Body.NodeType));
         }
         
         /// <summary>

--- a/LightMock/MockContext.cs
+++ b/LightMock/MockContext.cs
@@ -68,6 +68,20 @@ namespace LightMock
         }
 
         /// <summary>
+        /// Arranges a mocked property. 
+        /// </summary>
+        /// <typeparam name="TResult">The type of value returned from the mocked property.</typeparam>
+        /// <param name="matchExpression">The match expression that describes where 
+        /// this <see cref="PropertyArrangement{TResult}"/> will be applied.</param>
+        /// <returns>A new <see cref="PropertyArrangement{TResult}"/> used to apply property behavior.</returns>
+        public PropertyArrangement<TResult> ArrangeProperty<TResult>(Expression<Func<TMock, TResult>> matchExpression)
+        {
+            var arrangement = new PropertyArrangement<TResult>(matchExpression);
+            arrangements.Add(arrangement);
+            return arrangement;
+        }
+
+        /// <summary>
         /// Verifies that the method represented by the <paramref name="matchExpression"/> has 
         /// been invoked.
         /// </summary>
@@ -135,6 +149,26 @@ namespace LightMock
             }
 
             return default(TResult);
-        }                
+        }
+
+        /// <summary>
+        /// Tracks that the setter represented by the <paramref name="expression"/>
+        /// has been invoked.
+        /// </summary>
+        /// <param name="expression">The <see cref="Expression{TDelegate}"/> that 
+        /// represents the setter that has been invoked.</param>
+        /// <param name="value">The value</param>
+        void IInvocationContext<TMock>.InvokeSetter<TResult>(Expression<Func<TMock, TResult>> expression, object value)
+        {
+            var invocationInfo = expression.ToInvocationInfo();
+            invocations.Add(invocationInfo);
+
+            var arrangement = arrangements.FirstOrDefault(a => a.Matches(invocationInfo));
+            if (arrangement != null)
+            {
+                arrangement.Execute(new[] { value });
+            }
+        }
+
     }
 }

--- a/LightMock/PropertyArrangement.cs
+++ b/LightMock/PropertyArrangement.cs
@@ -1,0 +1,39 @@
+﻿
+using System.Linq.Expressions;
+
+namespace LightMock
+{
+    /// <summary>
+    /// A class that represents an arrangement of a mocked property that 
+    /// returns a value of type <typeparamref name="TResult"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the return value of the mocked property.</typeparam>
+    public class PropertyArrangement<TResult> : Arrangement
+    {
+        private TResult result;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyArrangement{TResult}"/> class.
+        /// </summary>
+        /// <param name="expression">The <see cref="LambdaExpression"/> that specifies
+        /// where to apply this <see cref="Arrangement"/>.</param>
+        public PropertyArrangement(LambdaExpression expression)
+            : base(expression)
+        {
+        }
+
+        /// <summary>
+        /// Executes the arrangement.
+        /// </summary>
+        /// <param name="arguments">The arguments used to invoke the mocked method.</param>
+        /// <returns>The registered return value, if any, otherwise, the default value.</returns>
+        internal override object Execute(object[] arguments)
+        {
+            base.Execute(arguments);
+
+            if (arguments != null && arguments.Length > 0) result = (TResult)arguments[0];
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
I extended Arrangement<TResult> class with Returns methods containing Func delegate. This is especially useful if there is a need to calculate the result value just when mocked method is invoked and/or basing on input parameters.