### PR TITLE
Added support for callbacks with five and six parameters

### DIFF
--- a/LightMock.Tests/ArrangementTests.cs
+++ b/LightMock.Tests/ArrangementTests.cs
@@ -98,6 +98,71 @@
         }
 
         [TestMethod]
+        public void Arrange_CallBackFiveArguments_InvokesCallback()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            int firstResult = 0;
+            int secondResult = 0;
+            int thirdResult = 0;
+            int fourthResult = 0;
+            int fifthResult = 0;
+            mockContext.Arrange(
+                f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue))
+                .Callback<int, int, int, int, int>(
+                    (i1, i2, i3, i4, i5) =>
+                    {
+                        firstResult = i1;
+                        secondResult = i2;
+                        thirdResult = i3;
+                        fourthResult = i4;
+                        fifthResult = i5;
+                    });
+
+            fooMock.Execute(1, 2, 3, 4, 5);
+
+            Assert.AreEqual(1, firstResult);
+            Assert.AreEqual(2, secondResult);
+            Assert.AreEqual(3, thirdResult);
+            Assert.AreEqual(4, fourthResult);
+            Assert.AreEqual(5, fifthResult);
+        }
+
+        [TestMethod]
+        public void Arrange_CallBackSixArguments_InvokesCallback()
+        {
+            var mockContext = new MockContext<IFoo>();
+            var fooMock = new FooMock(mockContext);
+            int firstResult = 0;
+            int secondResult = 0;
+            int thirdResult = 0;
+            int fourthResult = 0;
+            int fifthResult = 0;
+            int sixthResult = 0;
+            mockContext.Arrange(
+                f => f.Execute(The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue, The<int>.IsAnyValue))
+                .Callback<int, int, int, int, int, int>(
+                    (i1, i2, i3, i4, i5, i6) =>
+                    {
+                        firstResult = i1;
+                        secondResult = i2;
+                        thirdResult = i3;
+                        fourthResult = i4;
+                        fifthResult = i5;
+                        sixthResult = i6;
+                    });
+
+            fooMock.Execute(1, 2, 3, 4, 5, 6);
+
+            Assert.AreEqual(1, firstResult);
+            Assert.AreEqual(2, secondResult);
+            Assert.AreEqual(3, thirdResult);
+            Assert.AreEqual(4, fourthResult);
+            Assert.AreEqual(5, fifthResult);
+            Assert.AreEqual(6, sixthResult);
+        }
+
+        [TestMethod]
         public void Arrange_ReturnsWithNoArguments_InvokesGetResult()
         {
             var mockContext = new MockContext<IFoo>();

--- a/LightMock.Tests/FooMock.cs
+++ b/LightMock.Tests/FooMock.cs
@@ -36,6 +36,15 @@
             context.Invoke(f => f.Execute(first, second, third, fourth));
         }
 
+        public void Execute(int first, int second, int third, int fourth, int fifth)
+        {
+            context.Invoke(f => f.Execute(first, second, third, fourth, fifth));
+        }
+        public void Execute(int first, int second, int third, int fourth, int fifth, int sixth)
+        {
+            context.Invoke(f => f.Execute(first, second, third, fourth, fifth, sixth));
+        }
+
         public string Execute()
         {
             return context.Invoke(f => f.Execute());

--- a/LightMock.Tests/IFoo.cs
+++ b/LightMock.Tests/IFoo.cs
@@ -6,6 +6,8 @@
         void Execute(int first, int second);
         void Execute(int first, int second, int third);
         void Execute(int first, int second, int third, int fourth);
+        void Execute(int first, int second, int third, int fourth, int fifth);
+        void Execute(int first, int second, int third, int fourth, int fifth, int sixth);
 
         string Execute();
         string Execute(string value);

--- a/LightMock/Arrangement.cs
+++ b/LightMock/Arrangement.cs
@@ -123,6 +123,35 @@ namespace LightMock
         }
 
         /// <summary>
+        /// Arranges for the <paramref name="callBack"/> to be called when the mocked method is invoked.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter.</typeparam>
+        /// <param name="callBack">The <see cref="Action{T1,T2}"/> to be called when the mocked method is invoked.</param>
+        public void Callback<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> callBack)
+        {
+            actions.Add(args => callBack.DynamicInvoke(args));
+        }
+
+        /// <summary>
+        /// Arranges for the <paramref name="callBack"/> to be called when the mocked method is invoked.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter.</typeparam>
+        /// <param name="callBack">The <see cref="Action{T1,T2}"/> to be called when the mocked method is invoked.</param>
+        public void Callback<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> callBack)
+        {
+            actions.Add(args => callBack.DynamicInvoke(args));
+        }
+
+        /// <summary>
         /// Determines if the <paramref name="invocationInfo"/> matches this <see cref="Arrangement"/>.
         /// </summary>
         /// <param name="invocationInfo">The <see cref="InvocationInfo"/> that represents the method invocation.</param>


### PR DESCRIPTION
I want to use LightMock for mocking in my UWP application however I found that the arrangement callbacks only allowed methods with up to four parameters. I needed one with six parameters. I have implemented this in this pull request and added support for five parameters simply for completeness. I have also added the requisite unit tests.

Thanks,
Gary